### PR TITLE
#19 add multi select, canvas zoom, canvas background

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
   ignorePatterns: [".eslintrc.js", "postcss.config.js", "tailwind.config.js"],
   rules: {
     "no-unused-vars": "off",
+    "no-underscore-dangle": "off",
     "@typescript-eslint/no-unused-vars": ["error"],
     "no-use-before-define": "off",
     "@typescript-eslint/no-use-before-define": ["error"],

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,9 @@
       "name": "client",
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.1.1",
+        "@fortawesome/free-solid-svg-icons": "^6.1.1",
+        "@fortawesome/react-fontawesome": "^0.2.0",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
@@ -2178,6 +2181,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.1.tgz",
+      "integrity": "sha512-wVn5WJPirFTnzN6tR95abCx+ocH+3IFLXAgyavnf9hUmN0CfWoDjPT/BAWsUVwSlYYVBeCLJxaqi7ZGe4uSjBA==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.1.tgz",
+      "integrity": "sha512-NCg0w2YIp81f4V6cMGD9iomfsIj7GWrqmsa0ZsPh59G7PKiGN1KymZNxmF00ssuAlo/VZmpK6xazsGOwzKYUMg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.1.1.tgz",
+      "integrity": "sha512-0/5exxavOhI/D4Ovm2r3vxNojGZioPwmFrKg0ZUH69Q68uFhFPs6+dhAToh6VEQBntxPRYPuT5Cg1tpNa9JUPg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -18732,6 +18780,35 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         }
+      }
+    },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.1.tgz",
+      "integrity": "sha512-wVn5WJPirFTnzN6tR95abCx+ocH+3IFLXAgyavnf9hUmN0CfWoDjPT/BAWsUVwSlYYVBeCLJxaqi7ZGe4uSjBA=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.1.tgz",
+      "integrity": "sha512-NCg0w2YIp81f4V6cMGD9iomfsIj7GWrqmsa0ZsPh59G7PKiGN1KymZNxmF00ssuAlo/VZmpK6xazsGOwzKYUMg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.1.1"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.1.1.tgz",
+      "integrity": "sha512-0/5exxavOhI/D4Ovm2r3vxNojGZioPwmFrKg0ZUH69Q68uFhFPs6+dhAToh6VEQBntxPRYPuT5Cg1tpNa9JUPg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.1.1"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+      "requires": {
+        "prop-types": "^15.8.1"
       }
     },
     "@humanwhocodes/config-array": {

--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.1.1",
+    "@fortawesome/free-solid-svg-icons": "^6.1.1",
+    "@fortawesome/react-fontawesome": "^0.2.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,51 +1,81 @@
-import React from "react";
+import React, { useContext, useState } from "react";
 import { Link } from "react-router-dom";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faSun, faMoon } from "@fortawesome/free-solid-svg-icons";
+import { RoomContext } from "../context/RoomContext";
 
-const Header = () => (
-  <header className="bg-transparent text-gray-600 body-font z-50">
-    <div className="container mx-auto flex flex-wrap p-5 flex-col md:flex-row items-center">
-      <Link to="/" className="flex title-font font-medium items-center text-gray-900 mb-4 md:mb-0">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          stroke="currentColor"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="2"
-          className="w-10 h-10 text-white p-2 bg-indigo-500 rounded-full"
-          viewBox="0 0 24 24"
-        >
-          <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" />
-        </svg>
-        <span className="ml-3 text-xl">Mindmap</span>
-      </Link>
-      <nav className="md:mr-auto md:ml-4 md:py-1 md:pl-4 md:border-l md:border-gray-400	flex flex-wrap items-center text-base justify-center">
-        <Link to="/" className="mr-5 hover:text-gray-900">
-          Home
+const Header = () => {
+  const { setStageStyle } = useContext(RoomContext);
+  const [dark, setDark] = useState(false);
+  return (
+    <header className="bg-transparent text-gray-600 body-font z-50">
+      <div className="container mx-auto flex flex-wrap p-5 flex-col md:flex-row items-center">
+        <Link to="/" className="flex title-font font-medium items-center text-gray-900 mb-4 md:mb-0">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            className="w-10 h-10 text-white p-2 bg-indigo-500 rounded-full"
+            viewBox="0 0 24 24"
+          >
+            <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" />
+          </svg>
+          <span className="ml-3 text-xl">Mindmap</span>
         </Link>
-        <Link to="/room" className="mr-5 hover:text-gray-900">
-          Room
-        </Link>
-      </nav>
-      <button
-        type="button"
-        className="inline-flex items-center bg-gray-100 border-0 py-1 px-3 focus:outline-none hover:bg-gray-200 rounded text-base mt-4 md:mt-0"
-      >
-        Login
-        <svg
-          fill="none"
-          stroke="currentColor"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="2"
-          className="w-4 h-4 ml-1"
-          viewBox="0 0 24 24"
+        <nav className="md:mr-auto md:ml-4 md:py-1 md:pl-4 md:border-l md:border-gray-400	flex flex-wrap items-center text-base justify-center">
+          <Link to="/" className="mr-5 hover:text-gray-900">
+            Home
+          </Link>
+          <Link to="/room" className="mr-5 hover:text-gray-900">
+            Room
+          </Link>
+        </nav>
+        <FontAwesomeIcon
+          className="px-5 cursor-pointer"
+          icon={dark ? faSun : faMoon}
+          color={dark ? "#f8fafc" : "#6b7280"}
+          fontSize={30}
+          onClick={() => {
+            if (!dark) {
+              setStageStyle((prevState) => ({
+                ...prevState,
+                backgroundColor: "#6b7280",
+                backgroundImage: "radial-gradient(#cbd5e1 1.1px, #6b7280 1.1px)",
+              }));
+              setDark(true);
+            } else {
+              setStageStyle((prevState) => ({
+                ...prevState,
+                backgroundColor: "#f8fafc",
+                backgroundImage: "radial-gradient(#6b7280 1.1px, #f8fafc 1.1px)",
+              }));
+              setDark(false);
+            }
+          }}
+        />
+        <button
+          type="button"
+          className="inline-flex items-center bg-gray-100 border-0 py-1 px-3 focus:outline-none hover:bg-gray-200 rounded text-base mt-4 md:mt-0"
         >
-          <path d="M5 12h14M12 5l7 7-7 7" />
-        </svg>
-      </button>
-    </div>
-  </header>
-);
+          Login
+          <svg
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            className="w-4 h-4 ml-1"
+            viewBox="0 0 24 24"
+          >
+            <path d="M5 12h14M12 5l7 7-7 7" />
+          </svg>
+        </button>
+      </div>
+    </header>
+  );
+};
 
 export default Header;

--- a/client/src/components/RoomPage/Edge.tsx
+++ b/client/src/components/RoomPage/Edge.tsx
@@ -14,13 +14,11 @@ const Edge: React.FC<Props> = ({ node }) => {
     const dy = to.y - from.y;
     const angle = Math.atan2(-dy, dx);
 
-    const radius = 60;
-
     return [
-      from.x + -radius * Math.cos(angle + Math.PI),
-      from.y + radius * Math.sin(angle + Math.PI),
-      to.x + -radius * Math.cos(angle),
-      to.y + radius * Math.sin(angle),
+      from.x - Math.cos(angle + Math.PI),
+      from.y + Math.sin(angle + Math.PI),
+      to.x - Math.cos(angle),
+      to.y + Math.sin(angle),
     ];
   };
 
@@ -29,7 +27,13 @@ const Edge: React.FC<Props> = ({ node }) => {
       {node.children.map((childId) => {
         const childNode = nodes.filter((_node) => _node.id === childId)[0];
         return (
-          <Line key={`${node.id}_${childId}`} points={getEdgePoints(node, childNode)} stroke="#9CA3AF" dash={[8, 4]} />
+          <Line
+            key={`${node.id}_${childId}`}
+            points={getEdgePoints(node, childNode)}
+            stroke="#9CA3AF"
+            strokeWidth={4}
+            dash={[8, 4]}
+          />
         );
       })}
     </>

--- a/client/src/components/RoomPage/Shape.tsx
+++ b/client/src/components/RoomPage/Shape.tsx
@@ -1,42 +1,40 @@
-import React, { useContext, useRef } from "react";
+import React, { useContext, useEffect, useRef } from "react";
 import Konva from "konva";
-import { Group, Circle } from "react-konva";
+import { Ellipse, Group } from "react-konva";
 import { RoomContext, Node } from "../../context/RoomContext";
 import ShapeText from "./ShapeText";
 
 type Props = {
   node: Node;
-  ind: number;
 };
 
-const Shape: React.FC<Props> = ({ node, ind }) => {
-  const { nodes, setNodes, selectedNode, setSelectedNode, setShapeRefs } = useContext(RoomContext);
+const Shape: React.FC<Props> = ({ node }) => {
+  const { nodes, setNodes, selectedNode, setSelectedNode, selectedShapes, setSelectedShapes } = useContext(RoomContext);
   const shapeRef = useRef<Konva.Group>(null);
+
+  useEffect(() => {
+    // add node.id as attribute to ref of shape
+    shapeRef.current?.setAttr("id", node.id);
+  }, [node.id]);
 
   const handleDragMove = (e: Konva.KonvaEventObject<DragEvent>) => {
     setNodes(
-      nodes.map((currNode, i) => {
+      nodes.map((currNode) => {
         const { x, y } = e.target.position();
-        if (i === ind) {
+        // check if currNode is in selectedShapes
+        const otherSelectedShape = selectedShapes.find((shape) => currNode.id === shape.getAttr("id")) as Konva.Group;
+        if (currNode.id === node.id) {
           return {
             ...currNode,
             x,
             y,
-            isDragging: true,
           };
         }
-        return currNode;
-      })
-    );
-  };
-
-  const handleDragEnd = () => {
-    setNodes(
-      nodes.map((currNode, i) => {
-        if (i === ind) {
+        if (otherSelectedShape && otherSelectedShape.getAttr("id") !== node.id) {
           return {
             ...currNode,
-            isDragging: false,
+            x: otherSelectedShape.getAttr("x") as number,
+            y: otherSelectedShape.getAttr("y") as number,
           };
         }
         return currNode;
@@ -44,32 +42,99 @@ const Shape: React.FC<Props> = ({ node, ind }) => {
     );
   };
 
-  const handleClick = () => {
-    if (selectedNode) {
-      if (selectedNode !== node) {
-        setNodes(
-          nodes.map((currNode) => {
-            if (selectedNode.id === currNode.id) {
-              if (
-                !node.children.includes(currNode.id) &&
-                !currNode.children.includes(node.id) &&
-                currNode.id !== node.id
-              ) {
-                return {
-                  ...currNode,
-                  children: [...currNode.children, node.id],
-                };
-              }
-            }
-            return currNode;
-          })
-        );
-      }
+  const handleClick = (e: Konva.KonvaEventObject<MouseEvent>) => {
+    // shift でノードをクリックした場合、複数選択から追加・消去のみ行う
+    if (e.evt.shiftKey) {
       setSelectedNode(null);
-      // setShapeRefs((prevState) => prevState.filter((ref) => ref.current))
+      if (selectedShapes.find((shape) => shape._id === shapeRef.current?._id)) {
+        setSelectedShapes((prevState) => prevState.filter((shape) => shape._id !== shapeRef.current?._id));
+      } else {
+        setSelectedShapes((prevState) => [...prevState, shapeRef.current as Konva.Group]);
+      }
+      return;
+    }
+    if (selectedNode && selectedNode.id !== node.id) {
+      setNodes(
+        nodes.map((currNode) => {
+          if (selectedNode.id === currNode.id) {
+            if (
+              !node.children.includes(currNode.id) &&
+              !currNode.children.includes(node.id) &&
+              currNode.id !== node.id
+            ) {
+              return {
+                ...currNode,
+                children: [...currNode.children, node.id],
+              };
+            }
+          }
+          return currNode;
+        })
+      );
+      setSelectedNode(null);
+      setSelectedShapes([]);
     } else {
       setSelectedNode(node);
-      setShapeRefs((prevState) => [...prevState, shapeRef]);
+      setSelectedShapes([shapeRef.current as Konva.Group]);
+    }
+  };
+
+  const handleTransform = () => {
+    if (shapeRef.current) {
+      const currGroup = shapeRef.current;
+      setNodes(
+        nodes.map((currNode) => {
+          const otherSelectedShape = selectedShapes.find((shape) => currNode.id === shape.getAttr("id")) as Konva.Group;
+          if (currNode.id === node.id) {
+            return {
+              ...currNode,
+              x: currGroup.x(),
+              y: currGroup.y(),
+            };
+          }
+          if (otherSelectedShape && otherSelectedShape.getAttr("id") !== node.id) {
+            return {
+              ...currNode,
+              x: otherSelectedShape.getAttr("x") as number,
+              y: otherSelectedShape.getAttr("y") as number,
+            };
+          }
+          return currNode;
+        })
+      );
+    }
+  };
+
+  const handleTransformEnd = () => {
+    if (shapeRef.current) {
+      const currGroup = shapeRef.current;
+
+      const scaleX = currGroup.scaleX();
+      const scaleY = currGroup.scaleY();
+
+      currGroup.scaleX(1);
+      currGroup.scaleY(1);
+
+      setNodes(
+        nodes.map((currNode) => {
+          const otherSelectedShape = selectedShapes.find((shape) => currNode.id === shape.getAttr("id")) as Konva.Group;
+          if (currNode.id === node.id) {
+            return {
+              ...currNode,
+              width: currNode.width * scaleX,
+              height: currNode.height * scaleY,
+            };
+          }
+          if (otherSelectedShape && otherSelectedShape.getAttr("id") !== node.id) {
+            return {
+              ...currNode,
+              width: currNode.width * scaleX,
+              height: currNode.height * scaleY,
+            };
+          }
+          return currNode;
+        })
+      );
     }
   };
 
@@ -80,10 +145,13 @@ const Shape: React.FC<Props> = ({ node, ind }) => {
       y={node.y}
       draggable
       onDragMove={handleDragMove}
-      onDragEnd={handleDragEnd}
       onClick={handleClick}
+      onTap={handleClick}
+      onTransform={handleTransform}
+      onTransformEnd={handleTransformEnd}
+      name="mindmap-node"
     >
-      <Circle fill={node.fill} radius={50} shadowBlur={5} />
+      <Ellipse fill={node.fill} radiusX={node.width} radiusY={node.height} shadowBlur={5} />
       <ShapeText node={node} />
     </Group>
   );

--- a/client/src/context/RoomContext.tsx
+++ b/client/src/context/RoomContext.tsx
@@ -10,30 +10,46 @@ const generateNodes = () => {
   const nodes = [];
   for (let i = 0; i < 4; i += 1) {
     nodes.push({
-      id: i,
+      id: i.toString(),
       children: [],
       text: `node-${i}`,
       x: Math.random() * CANVAS_WIDTH,
       y: Math.random() * CANVAS_HEIGHT,
+      width: 100,
+      height: 100,
       fill: fills[Math.floor(Math.random() * fills.length)],
-      isDragging: false,
     });
   }
   return nodes;
 };
 
+type Props = {
+  children: React.ReactNode;
+};
+
 export type Node = {
-  id: number;
-  children: number[];
+  id: string;
+  children: string[];
   text: string;
   x: number;
   y: number;
-  isDragging: boolean;
+  width: number;
+  height: number;
   fill: string;
 };
 
-type Props = {
-  children: React.ReactNode;
+type StageConfig = {
+  stageScale: number;
+  stageX: number;
+  stageY: number;
+};
+
+type StageStyle = {
+  backgroundColor: string;
+  opacity: number;
+  backgroundImage: string;
+  backgroundSize: string;
+  backgroundPosition: string;
 };
 
 type IRoomContext = {
@@ -41,8 +57,12 @@ type IRoomContext = {
   setNodes: React.Dispatch<React.SetStateAction<Node[]>>;
   selectedNode: Node | null;
   setSelectedNode: React.Dispatch<React.SetStateAction<Node | null>>;
-  shapeRefs: React.RefObject<Konva.Group>[];
-  setShapeRefs: React.Dispatch<React.SetStateAction<React.RefObject<Konva.Group>[]>>;
+  selectedShapes: Konva.Group[];
+  setSelectedShapes: React.Dispatch<React.SetStateAction<Konva.Group[]>>;
+  stageConfig: StageConfig;
+  setStageConfig: React.Dispatch<React.SetStateAction<StageConfig>>;
+  stageStyle: StageStyle;
+  setStageStyle: React.Dispatch<React.SetStateAction<StageStyle>>;
 };
 
 export const RoomContext: React.Context<IRoomContext> = createContext({} as IRoomContext);
@@ -50,7 +70,19 @@ export const RoomContext: React.Context<IRoomContext> = createContext({} as IRoo
 export const RoomContextProvider: React.FC<Props> = ({ children }) => {
   const [nodes, setNodes] = useState<Node[]>(generateNodes());
   const [selectedNode, setSelectedNode] = useState<Node | null>(null);
-  const [shapeRefs, setShapeRefs] = useState<React.RefObject<Konva.Group>[]>([]);
+  const [selectedShapes, setSelectedShapes] = useState<Konva.Group[]>([]);
+  const [stageConfig, setStageConfig] = useState<StageConfig>({
+    stageScale: 0.8,
+    stageX: 0,
+    stageY: 0,
+  });
+  const [stageStyle, setStageStyle] = useState<StageStyle>({
+    backgroundColor: "#f8fafc",
+    opacity: 0.8,
+    backgroundImage: "radial-gradient(#6b7280 1.1px, #f8fafc 1.1px)",
+    backgroundSize: `${50 * stageConfig.stageScale}px ${50 * stageConfig.stageScale}px`,
+    backgroundPosition: "0px 0px",
+  });
 
   const value = useMemo(
     () => ({
@@ -58,10 +90,14 @@ export const RoomContextProvider: React.FC<Props> = ({ children }) => {
       setNodes,
       selectedNode,
       setSelectedNode,
-      shapeRefs,
-      setShapeRefs,
+      selectedShapes,
+      setSelectedShapes,
+      stageConfig,
+      setStageConfig,
+      stageStyle,
+      setStageStyle,
     }),
-    [nodes, selectedNode, shapeRefs]
+    [nodes, selectedNode, selectedShapes, stageConfig, stageStyle]
   );
 
   return <RoomContext.Provider value={value}>{children}</RoomContext.Provider>;

--- a/client/src/pages/RoomPage.tsx
+++ b/client/src/pages/RoomPage.tsx
@@ -1,21 +1,48 @@
-import React, { useContext, useRef, useEffect } from "react";
-import { Stage, Layer, Transformer } from "react-konva";
+import React, { useContext, useRef, useEffect, useState } from "react";
+import { Stage, Layer, Transformer, Rect } from "react-konva";
 import Konva from "konva";
 import { Node, RoomContext, fills, CANVAS_WIDTH, CANVAS_HEIGHT } from "../context/RoomContext";
 import Edge from "../components/RoomPage/Edge";
 import Shape from "../components/RoomPage/Shape";
 
 const RoomPage = () => {
-  const { nodes, setNodes, shapeRefs } = useContext(RoomContext);
+  const {
+    nodes,
+    setNodes,
+    selectedShapes,
+    setSelectedShapes,
+    setSelectedNode,
+    stageConfig,
+    setStageConfig,
+    stageStyle,
+    setStageStyle,
+  } = useContext(RoomContext);
+
+  const [canDragStage, setCanDragStage] = useState(true);
   const transformerRef = useRef<Konva.Transformer>(null);
+  const selectionRectRef = useRef<Konva.Rect>(null);
+  const [selectionRectCoords, setSelectionRectCoords] = useState({ x1: 0, y1: 0 });
+  const stageRef = useRef<Konva.Stage>(null);
 
   useEffect(() => {
-    if (shapeRefs) {
-      transformerRef.current?.nodes(shapeRefs.map((ref) => ref.current as Konva.Group));
+    if (selectedShapes) {
+      transformerRef.current?.nodes(selectedShapes);
       transformerRef.current?.getLayer()?.batchDraw();
     }
-  }, [shapeRefs]);
+  }, [selectedShapes, nodes]);
 
+  useEffect(() => {
+    window.addEventListener("keydown", (e: KeyboardEvent) => {
+      if (e.shiftKey) {
+        setCanDragStage(false);
+      }
+    });
+    window.addEventListener("keyup", () => {
+      setCanDragStage(true);
+    });
+  }, []);
+
+  // ダブルクリックでノードを追加
   const handleDoubleClick = (e: Konva.KonvaEventObject<MouseEvent>) => {
     const stage = e.target.getStage();
     let pointerPosition = null;
@@ -23,38 +50,168 @@ const RoomPage = () => {
       pointerPosition = stage.getRelativePointerPosition();
       if (pointerPosition) {
         const newNode: Node = {
-          id: nodes.length + 1,
+          id: nodes.length.toString(),
           children: [],
-          text: `node-${nodes.length + 1}`,
+          text: `node-${nodes.length}`,
           x: pointerPosition.x,
           y: pointerPosition.y,
+          width: 150,
+          height: 150,
           fill: fills[Math.floor(Math.random() * fills.length)],
-          isDragging: false,
         };
         setNodes((prevState) => [...prevState, newNode]);
       }
     }
   };
 
+  // マウススクロールで拡大・縮小
+  const handleWheel = (e: Konva.KonvaEventObject<WheelEvent>) => {
+    e.evt.preventDefault();
+    if (!canDragStage) {
+      return;
+    }
+    if (stageRef.current) {
+      const stage = stageRef.current;
+      const scaleBy = 1.05;
+      const oldScale = stageRef.current.scaleX();
+      const mousePointTo = {
+        x: (stage.getPointerPosition()?.x as number) / oldScale - stage.x() / oldScale,
+        y: (stage.getPointerPosition()?.y as number) / oldScale - stage.y() / oldScale,
+      };
+
+      const newScale = e.evt.deltaY < 0 ? oldScale * scaleBy : oldScale / scaleBy;
+
+      if (newScale > 2 || newScale < 0.1) {
+        return;
+      }
+
+      const stageX = -(mousePointTo.x - (stage.getPointerPosition()?.x as number) / newScale) * newScale;
+      const stageY = -(mousePointTo.y - (stage.getPointerPosition()?.y as number) / newScale) * newScale;
+
+      setStageConfig((prevState) => ({
+        ...prevState,
+        stageScale: newScale,
+        stageX,
+        stageY,
+      }));
+
+      setStageStyle((prevState) => ({
+        ...prevState,
+        backgroundSize: `${50 * newScale}px ${50 * newScale}px`,
+        backgroundPosition: `${stageX}px ${stageY}px`,
+      }));
+    }
+  };
+
+  // マウスドラッグで Canvas 内を移動
+  const handleDragMove = (e: Konva.KonvaEventObject<DragEvent>) => {
+    if (e.target === stageRef.current && canDragStage) {
+      setStageStyle((prevState) => ({
+        ...prevState,
+        backgroundPosition: `${e.target.x()}px ${e.target.y()}px`,
+      }));
+    }
+  };
+
+  // マウスクリックでノード選択解除
+  const handleClick = (e: Konva.KonvaEventObject<MouseEvent>) => {
+    if (e.target === stageRef.current) {
+      setSelectedNode(null);
+      setSelectedShapes([]);
+    }
+  };
+
+  // マウスダウンで複数選択を開始
+  const handleMouseDown = (e: Konva.KonvaEventObject<MouseEvent>) => {
+    if (e.target !== stageRef.current || canDragStage) {
+      return;
+    }
+    e.evt.preventDefault();
+    const X1 = stageRef.current.getRelativePointerPosition()?.x;
+    const X2 = stageRef.current.getRelativePointerPosition()?.y;
+    setSelectionRectCoords({
+      x1: X1,
+      y1: X2,
+    });
+
+    selectionRectRef.current?.visible(true);
+    selectionRectRef.current?.width(0);
+    selectionRectRef.current?.height(0);
+    selectionRectRef.current?.setAttrs({
+      x: X1,
+      y: X2,
+    });
+  };
+
+  // マウスムーブで複数選択範囲を設定
+  const handleMouseMove = (e: Konva.KonvaEventObject<MouseEvent>) => {
+    if (!selectionRectRef.current?.visible() || canDragStage) {
+      selectionRectRef.current?.visible(false);
+      return;
+    }
+    e.evt.preventDefault();
+    const x2 = stageRef.current?.getRelativePointerPosition()?.x;
+    const y2 = stageRef.current?.getRelativePointerPosition()?.y;
+    if (selectionRectCoords && x2 && y2) {
+      selectionRectRef.current.setAttrs({
+        x: Math.min(selectionRectCoords.x1, x2),
+        y: Math.min(selectionRectCoords.y1, y2),
+        width: Math.abs(x2 - selectionRectCoords.x1),
+        height: Math.abs(y2 - selectionRectCoords.y1),
+      });
+    }
+  };
+
+  // マウスアップで複数選択範囲を確定
+  const handleMouseUp = (e: Konva.KonvaEventObject<MouseEvent>) => {
+    if (!selectionRectRef.current?.visible() || canDragStage) {
+      selectionRectRef.current?.visible(false);
+      return;
+    }
+    e.evt.preventDefault();
+    setTimeout(() => {
+      selectionRectRef.current?.visible(false);
+    });
+    const shapes = stageRef.current?.find(".mindmap-node");
+    const box = selectionRectRef.current?.getClientRect();
+    const selected = shapes?.filter((shape) => Konva.Util.haveIntersection(box, shape.getClientRect()));
+    setSelectedShapes(selected as Konva.Group[]);
+  };
+
   return (
     <RoomContext.Consumer>
       {(value) => (
         <Stage
+          style={stageStyle}
+          ref={stageRef}
           className="-z-10 absolute top-0"
+          scaleX={stageConfig.stageScale}
+          scaleY={stageConfig.stageScale}
+          x={stageConfig.stageX}
+          y={stageConfig.stageY}
           width={CANVAS_WIDTH}
           height={CANVAS_HEIGHT}
+          draggable={canDragStage}
+          onDragMove={handleDragMove}
+          onClick={handleClick}
+          onTap={handleClick}
+          onMouseDown={handleMouseDown}
+          onMouseMove={handleMouseMove}
+          onMouseUp={handleMouseUp}
           onDblClick={handleDoubleClick}
-          draggable
+          onDblTap={handleDoubleClick}
+          onWheel={handleWheel}
         >
           <RoomContext.Provider value={value}>
             <Layer>
               {nodes.map((node) => (
                 <Edge key={node.id} node={node} />
               ))}
-              {nodes.map((node, ind) => (
-                <Shape key={node.id} node={node} ind={ind} />
+              {nodes.map((node) => (
+                <Shape key={node.id} node={node} />
               ))}
-              {shapeRefs && <Transformer ref={transformerRef} />}
+              {selectedShapes && <Transformer ref={transformerRef} rotateEnabled={false} />}
+              <Rect ref={selectionRectRef} fill="rgba(99,102,241,0.2)" visible={false} />
             </Layer>
           </RoomContext.Provider>
         </Stage>


### PR DESCRIPTION
## Issue: #19 
## 目的
- ノードの複数選択・解除
- Canvas (Stage) の拡大・縮小
- その他:
  - Canvas (Stage) に背景追加 (試し）
  - Dark・Light モード (試し）

## 導入内容
- 複数選択
  - 各ノードを shift + click で現在選択しているノード配列に追加
  - 既に選択しているノードを shift + click する事でそのノードを現在選択しているノード配列から消去
  - shift + mousedown + mousemove で複数選択したい範囲を調整し、mouseup で確定
  - ノードの大きさを変更する際、幅と高さを記録する必要があったため width, height を Node 型に追加

- Stage の拡大・縮小
  - mousescroll で現在のマウスの座標を支点として拡大・縮小を行う -> Stage の scale を変更している
  - Stage の scale, x, y を状態管理する stageConfig を RoomContext に追加
```ts
type StageConfig = {
  stageScale: number;
  stageX: number;
  stageY: number;
};
```

- Stage 背景
  - Stage の背景のスタイリングを状態管理する stageStyle を RoomContext に追加
  - 状態で管理する事で dark・light 選択が可能
```ts
type StageStyle = {
  backgroundColor: string;
  opacity: number;
  backgroundImage: string;
  backgroundSize: string;
  backgroundPosition: string;
};
```