### PR TITLE
#42 add Undo and Redo for keybord operation

### DIFF
--- a/client/src/components/RoomPage/ToolBox/ToolBox.tsx
+++ b/client/src/components/RoomPage/ToolBox/ToolBox.tsx
@@ -25,18 +25,18 @@ const ToolBox = () => {
   const handleUndo = () => {
     if (historyIndex > 0) {
       const prevIndex: number = historyIndex - 1;
-      const newHistory = new Map(history[prevIndex]);
-      setNodes(newHistory);
+      const prevHistory = new Map(history[prevIndex]);
+      setNodes(prevHistory);
       setHistoryIndex(prevIndex);
     }
   };
 
   const handleRedo = () => {
     if (history.length - 1 > historyIndex) {
-      const frontIndex: number = historyIndex + 1;
-      const newHistory = new Map(history[frontIndex]);
-      setNodes(newHistory);
-      setHistoryIndex(frontIndex);
+      const nextIndex: number = historyIndex + 1;
+      const nextHistory = new Map(history[nextIndex]);
+      setNodes(nextHistory);
+      setHistoryIndex(nextIndex);
     }
   };
 

--- a/client/src/hooks/useHistory.tsx
+++ b/client/src/hooks/useHistory.tsx
@@ -1,8 +1,8 @@
-import { useContext } from "react";
+import { useCallback, useContext } from "react";
 import { Node, RoomContext } from "../context/RoomContext";
 
 const useHistory = () => {
-  const { history, setHistory, setHistoryIndex } = useContext(RoomContext);
+  const { setNodes, history, setHistory, historyIndex, setHistoryIndex } = useContext(RoomContext);
 
   // const addHistoryByDoubleClick = (newNode: Node) => {
   //   const newMap = new Map(nodes);
@@ -20,6 +20,33 @@ const useHistory = () => {
   //   const len = history.length;
   //   setHistoryIndex(len);
   // };
+  const undoByShortcutKey = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.code === "KeyZ" && (e.ctrlKey || e.metaKey)) {
+        if (historyIndex > 0) {
+          const prevIndex: number = historyIndex - 1;
+          const prevHistory = new Map(history[prevIndex]);
+          setNodes(prevHistory);
+          setHistoryIndex(prevIndex);
+        }
+      }
+    },
+    [history, historyIndex, setHistoryIndex, setNodes]
+  );
+
+  const redoByShortcutKey = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.code === "KeyY" && (e.ctrlKey || e.metaKey)) {
+        if (history.length - 1 > historyIndex) {
+          const nextIndex: number = historyIndex + 1;
+          const nextHistory = new Map(history[nextIndex]);
+          setNodes(nextHistory);
+          setHistoryIndex(nextIndex);
+        }
+      }
+    },
+    [history, historyIndex, setHistoryIndex, setNodes]
+  );
 
   const addToHistory = (updatedNodes: Map<string, Node>) => {
     const newMap = new Map(updatedNodes);
@@ -29,7 +56,7 @@ const useHistory = () => {
     setHistoryIndex(len);
   };
 
-  return { addToHistory };
+  return { addToHistory, undoByShortcutKey, redoByShortcutKey };
 };
 
 export default useHistory;

--- a/client/src/pages/RoomPage.tsx
+++ b/client/src/pages/RoomPage.tsx
@@ -25,6 +25,9 @@ const RoomPage = () => {
     fillStyle,
     strokeStyle,
     setDisplayColorPicker,
+    history,
+    historyIndex,
+    setHistoryIndex,
   } = useContext(RoomContext);
 
   const [canDragStage, setCanDragStage] = useState(true);
@@ -32,7 +35,16 @@ const RoomPage = () => {
   const selectionRectRef = useRef<Konva.Rect>(null);
   const [selectionRectCoords, setSelectionRectCoords] = useState({ x1: 0, y1: 0 });
   const stageRef = useRef<Konva.Stage>(null);
-  const { addToHistory } = useHistory();
+  const { addToHistory, undoByShortcutKey, redoByShortcutKey } = useHistory();
+
+  useEffect(() => {
+    document.addEventListener("keydown", undoByShortcutKey);
+    document.addEventListener("keydown", redoByShortcutKey);
+    return () => {
+      document.removeEventListener("keydown", undoByShortcutKey);
+      document.removeEventListener("keydown", redoByShortcutKey);
+    };
+  }, [historyIndex, history, setHistoryIndex, setNodes, undoByShortcutKey, redoByShortcutKey]);
 
   useEffect(() => {
     if (stageRef.current) {


### PR DESCRIPTION
## Issue: #42
## 目的
- undo、redoをctrl+z、ctrl+yのキーボード操作で行えるようにする。
## 導入内容
- hooksのuseHistoryにundo、redoの関数を追記
- RoomPage内で、useEffect内でkeydownのイベントリスナーを追記